### PR TITLE
Ensure wrapping nil is still nil

### DIFF
--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ type Error struct {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
-func New(e interface{}) *Error {
+func New(e interface{}) error {
 	var err error
 
 	switch e := e.(type) {
@@ -90,7 +90,19 @@ func New(e interface{}) *Error {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
 // to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
-func Wrap(e interface{}, skip int) *Error {
+// Wrapping nil returns nil.
+func Wrap(e interface{}, skip int) error {
+	return WrapPrefix(e, "", skip+1)
+}
+
+// WrapPrefix makes an Error from the given value. If that value is already an
+// error then it will be used directly, if not, it will be passed to
+// fmt.Errorf("%v"). The prefix parameter is used to add a prefix to the
+// error message when calling Error(). The skip parameter indicates how far
+// up the stack to start the stacktrace. 0 is from the current call,
+// 1 from its caller, etc.
+// Wrapping nil returns nil.
+func WrapPrefix(e interface{}, prefix string, skip int) error {
 	if e == nil {
 		return nil
 	}
@@ -99,7 +111,7 @@ func Wrap(e interface{}, skip int) *Error {
 
 	switch e := e.(type) {
 	case *Error:
-		return e
+		return e.withPrefix(prefix)
 	case error:
 		err = e
 	default:
@@ -109,40 +121,16 @@ func Wrap(e interface{}, skip int) *Error {
 	stack := make([]uintptr, MaxStackDepth)
 	length := runtime.Callers(2+skip, stack[:])
 	return &Error{
-		Err:   err,
-		stack: stack[:length],
-	}
-}
-
-// WrapPrefix makes an Error from the given value. If that value is already an
-// error then it will be used directly, if not, it will be passed to
-// fmt.Errorf("%v"). The prefix parameter is used to add a prefix to the
-// error message when calling Error(). The skip parameter indicates how far
-// up the stack to start the stacktrace. 0 is from the current call,
-// 1 from its caller, etc.
-func WrapPrefix(e interface{}, prefix string, skip int) *Error {
-	if e == nil {
-		return nil
-	}
-
-	err := Wrap(e, 1+skip)
-
-	if err.prefix != "" {
-		prefix = fmt.Sprintf("%s: %s", prefix, err.prefix)
-	}
-
-	return &Error{
-		Err:    err.Err,
-		stack:  err.stack,
+		Err:    err,
+		stack:  stack[:length],
 		prefix: prefix,
 	}
-
 }
 
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
-func Errorf(format string, a ...interface{}) *Error {
+func Errorf(format string, a ...interface{}) error {
 	return Wrap(fmt.Errorf(format, a...), 1)
 }
 
@@ -206,4 +194,15 @@ func (err *Error) TypeName() string {
 // Return the wrapped error (implements api for As function).
 func (err *Error) Unwrap() error {
 	return err.Err
+}
+
+func (err *Error) withPrefix(prefix string) error {
+	if err.prefix == "" {
+		return err
+	}
+	return &Error{
+		Err:    err.Err,
+		stack:  err.stack,
+		prefix: fmt.Sprintf("%s: %s", prefix, err.prefix),
+	}
 }

--- a/error.go
+++ b/error.go
@@ -134,6 +134,13 @@ func Errorf(format string, a ...interface{}) error {
 	return Wrap(fmt.Errorf(format, a...), 1)
 }
 
+// ErrorStack is a convenience function that returns an error's error message
+// and callstack of a non nil error. If the provided error has no callstack
+// one will be created to the call-site of this function.
+func ErrorStack(err error) string {
+	return Wrap(err, 1).(*Error).ErrorStack()
+}
+
 // Error returns the underlying error's message.
 func (err *Error) Error() string {
 

--- a/error_test.go
+++ b/error_test.go
@@ -210,6 +210,20 @@ func TestWrapPrefixError(t *testing.T) {
 	}
 }
 
+func TestNilErrIsNil(t *testing.T) {
+	if err := foo(); err != nil {
+		panic("not nil")
+	}
+}
+
+func foo() error {
+	return Wrap(bar(), 0)
+}
+
+func bar() error {
+	return nil
+}
+
 func ExampleErrorf(x int) (int, error) {
 	if x%2 == 1 {
 		return 0, Errorf("can only halve even numbers, got %d", x)

--- a/error_test.go
+++ b/error_test.go
@@ -226,6 +226,17 @@ func libraryCode() error {
 	return nil
 }
 
+func TestStackError(t *testing.T) {
+
+	err := func() error {
+		return New("foo")
+	}()
+
+	if err.(*Error).ErrorStack() != ErrorStack(err) {
+		panic("err.ErrorStack() and ErrorStack(err) should be equal but differs")
+	}
+}
+
 func ExampleErrorf(x int) (int, error) {
 	if x%2 == 1 {
 		return 0, Errorf("can only halve even numbers, got %d", x)


### PR DESCRIPTION
This PR makes it possible to write code like:

```golang
func myCode() error {
    // …

    // Next line would previously always return a non nil error
    return errors.Wrap(libraryCode(), 0)
}
```

Accessing the stack trace becomes harder. Previously this could be done with `errors.Wrap(err, 0).ErrorStack()` but now that `Wrap` returns `error` you would have to write `errors.Wrap(err, 0).(*errors.Error).ErrorStack()`. To simplify access of the stack trace a new top level function has been added so that you can do: `errors.ErrorStack(err)` to access the stack trace.

If there is no stack trace